### PR TITLE
Pin xz to 5.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: d04fba2d9245e661f245de0577f48a33
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: true                             # [win]
 
@@ -18,11 +18,11 @@ requirements:
   build:
     - libpng 1.6*
     - zlib 1.2*
-    - xz 5.2.*
+    - xz 5.0.*
   run:
     - libpng 1.6*
     - zlib 1.2*
-    - xz 5.2.*
+    - xz 5.0.*
 
 test:
   commands:


### PR DESCRIPTION
This will allow to install `sox` along side the rest of the software in `conda-forge`.