### PR TITLE
Remove build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ os: osx
 osx_image: xcode6.4
 
 env:
-  matrix:
-    
-    - LIBPNG_VERSION="1.6.27"
-    - LIBPNG_VERSION="1.6.28"
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "wTwKTlN/RcNbFNxJdrYgzBcyf+2TEHzi/YeXfjkhlZYn4j1XTLv4ggOxyvCUToufL2+BURjgc4cq8M7ccNWqq8atduY811yGH46OjaT/QHrOsfNG9+mw+PqS42gzk9sqTOfoTEOUDgLFqLrESUSqmVXckefupWCA6XoLa8QdIJeAuXHJE9ev45GaouVQQMfUr1h4F1/vzBijI73wEGxQwdZJdapOAjZzhLdGAy19tiMMKO6/NhUfNYupFdvicIp6bhC2Uw8usTHtvkkLwLRnjL6zuYoGS+ZBromUmJvYvfpsGYPY9ZaOj5hYfwJek5SLbo0g9Qsavyp4VSGSNChab8985CegTwh11QuVjbi2ISDiIOeBgY0n3kxUlu5D/RryQp+rGoiqa/ZbYXpd/HaX8N3stWt78bFFKhtMXTCBBcYxPUGPwG/PaZjqbKtwqd0RRsAY8j3OZS9IooYT4VUBBPmwudaFCr5au7CHbewwaUCcMCl8fIt3bUOOy0endLvZXvKZdJwziY1kw9VPR/ZcwOijTdIE+DO7MLki8LAvg2rKA0bQoBVWgPZlfj8ixG1C67cBJgCP9RSyP/U2kVLOXhVow3VenRxOL1eiIdBK288j7aEVJDfXinTmgY5f0sgs921y8Fpvng9K6MbVlUlD11Zysru/IOVhNVt1wNfuYqw="

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,51 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
-    - LIBPNG_VERSION="1.6.22"
-    - LIBPNG_VERSION="1.6.26"
+    - LIBPNG_VERSION="1.6.27"
+    - LIBPNG_VERSION="1.6.28"
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "wTwKTlN/RcNbFNxJdrYgzBcyf+2TEHzi/YeXfjkhlZYn4j1XTLv4ggOxyvCUToufL2+BURjgc4cq8M7ccNWqq8atduY811yGH46OjaT/QHrOsfNG9+mw+PqS42gzk9sqTOfoTEOUDgLFqLrESUSqmVXckefupWCA6XoLa8QdIJeAuXHJE9ev45GaouVQQMfUr1h4F1/vzBijI73wEGxQwdZJdapOAjZzhLdGAy19tiMMKO6/NhUfNYupFdvicIp6bhC2Uw8usTHtvkkLwLRnjL6zuYoGS+ZBromUmJvYvfpsGYPY9ZaOj5hYfwJek5SLbo0g9Qsavyp4VSGSNChab8985CegTwh11QuVjbi2ISDiIOeBgY0n3kxUlu5D/RryQp+rGoiqa/ZbYXpd/HaX8N3stWt78bFFKhtMXTCBBcYxPUGPwG/PaZjqbKtwqd0RRsAY8j3OZS9IooYT4VUBBPmwudaFCr5au7CHbewwaUCcMCl8fIt3bUOOy0endLvZXvKZdJwziY1kw9VPR/ZcwOijTdIE+DO7MLki8LAvg2rKA0bQoBVWgPZlfj8ixG1C67cBJgCP9RSyP/U2kVLOXhVow3VenRxOL1eiIdBK288j7aEVJDfXinTmgY5f0sgs921y8Fpvng9K6MbVlUlD11Zysru/IOVhNVt1wNfuYqw="
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,16 +43,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 2 case(s).
-    set -x
-    export LIBPNG_VERSION="1.6.27"
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export LIBPNG_VERSION="1.6.28"
-    set +x
+# Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -43,14 +45,21 @@ source run_conda_forge_build_setup
 
 # Embarking on 2 case(s).
     set -x
-    export LIBPNG_VERSION="1.6.22"
+    export LIBPNG_VERSION="1.6.27"
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export LIBPNG_VERSION="1.6.26"
+    export LIBPNG_VERSION="1.6.28"
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,8 @@
 matrix:
   # default channel anaconda 4 requirements
-  - [[LIBPNG_VERSION, '"1.6.22"']]
+  - [[LIBPNG_VERSION, '"1.6.27"']]
   # conda-forge channel requirements.
-  - [[LIBPNG_VERSION, '"1.6.26"']]
+  - [[LIBPNG_VERSION, '"1.6.28"']]
 travis:
   secure:
     BINSTAR_TOKEN: wTwKTlN/RcNbFNxJdrYgzBcyf+2TEHzi/YeXfjkhlZYn4j1XTLv4ggOxyvCUToufL2+BURjgc4cq8M7ccNWqq8atduY811yGH46OjaT/QHrOsfNG9+mw+PqS42gzk9sqTOfoTEOUDgLFqLrESUSqmVXckefupWCA6XoLa8QdIJeAuXHJE9ev45GaouVQQMfUr1h4F1/vzBijI73wEGxQwdZJdapOAjZzhLdGAy19tiMMKO6/NhUfNYupFdvicIp6bhC2Uw8usTHtvkkLwLRnjL6zuYoGS+ZBromUmJvYvfpsGYPY9ZaOj5hYfwJek5SLbo0g9Qsavyp4VSGSNChab8985CegTwh11QuVjbi2ISDiIOeBgY0n3kxUlu5D/RryQp+rGoiqa/ZbYXpd/HaX8N3stWt78bFFKhtMXTCBBcYxPUGPwG/PaZjqbKtwqd0RRsAY8j3OZS9IooYT4VUBBPmwudaFCr5au7CHbewwaUCcMCl8fIt3bUOOy0endLvZXvKZdJwziY1kw9VPR/ZcwOijTdIE+DO7MLki8LAvg2rKA0bQoBVWgPZlfj8ixG1C67cBJgCP9RSyP/U2kVLOXhVow3VenRxOL1eiIdBK288j7aEVJDfXinTmgY5f0sgs921y8Fpvng9K6MbVlUlD11Zysru/IOVhNVt1wNfuYqw=

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,3 @@
-matrix:
-  # default channel anaconda 4 requirements
-  - [[LIBPNG_VERSION, '"1.6.27"']]
-  # conda-forge channel requirements.
-  - [[LIBPNG_VERSION, '"1.6.28"']]
 travis:
   secure:
     BINSTAR_TOKEN: wTwKTlN/RcNbFNxJdrYgzBcyf+2TEHzi/YeXfjkhlZYn4j1XTLv4ggOxyvCUToufL2+BURjgc4cq8M7ccNWqq8atduY811yGH46OjaT/QHrOsfNG9+mw+PqS42gzk9sqTOfoTEOUDgLFqLrESUSqmVXckefupWCA6XoLa8QdIJeAuXHJE9ev45GaouVQQMfUr1h4F1/vzBijI73wEGxQwdZJdapOAjZzhLdGAy19tiMMKO6/NhUfNYupFdvicIp6bhC2Uw8usTHtvkkLwLRnjL6zuYoGS+ZBromUmJvYvfpsGYPY9ZaOj5hYfwJek5SLbo0g9Qsavyp4VSGSNChab8985CegTwh11QuVjbi2ISDiIOeBgY0n3kxUlu5D/RryQp+rGoiqa/ZbYXpd/HaX8N3stWt78bFFKhtMXTCBBcYxPUGPwG/PaZjqbKtwqd0RRsAY8j3OZS9IooYT4VUBBPmwudaFCr5au7CHbewwaUCcMCl8fIt3bUOOy0endLvZXvKZdJwziY1kw9VPR/ZcwOijTdIE+DO7MLki8LAvg2rKA0bQoBVWgPZlfj8ixG1C67cBJgCP9RSyP/U2kVLOXhVow3VenRxOL1eiIdBK288j7aEVJDfXinTmgY5f0sgs921y8Fpvng9K6MbVlUlD11Zysru/IOVhNVt1wNfuYqw=

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "14.4.2" %}
-{% set build_number = "7" %}
+{% set build_number = "8" %}
 
 {% set libpng_version = os.environ.get('LIBPNG_VERSION', '1.6.22').replace('"','')|string %}
 {% set build_string = "libpng{}_{}".format(libpng_version, build_number) %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - toolchain
 
   run:
-    - libpng >=1.6.23,<1.7
+    - libpng >=1.6.28,<1.7
     - zlib 1.2.*
     - xz 5.2.*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,4 @@
 {% set version = "14.4.2" %}
-{% set build_number = "8" %}
-
-{% set libpng_version = os.environ.get('LIBPNG_VERSION', '1.6.22').replace('"','')|string %}
-{% set build_string = "libpng{}_{}".format(libpng_version, build_number) %}
 
 package:
   name: sox
@@ -14,20 +10,19 @@ source:
   md5: d04fba2d9245e661f245de0577f48a33
 
 build:
-  number: {{ build_number }}
-  string: {{ build_string }}
+  number: 8
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
 requirements:
   build:
-    - libpng {{ libpng_version }}
+    - libpng >=1.6.28,<1.7
     - zlib 1.2.*
     - xz 5.2.*
     - toolchain
 
   run:
-    - libpng {{ libpng_version }}
+    - libpng >=1.6.23,<1.7
     - zlib 1.2.*
     - xz 5.2.*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
   recipe-maintainers:
     - 183amir
     - alexbw
+    - sdvillal


### PR DESCRIPTION
Updates libpng in the build matrix, so that sox can be installed with the current versions in conda-forge and defaults.

Is there a reason for these dependencies to be pinned, instead of using a ">=" selector? When libpng gets updated upstream, good old sox build number 4 is the first to be selected, and that produces a chain of downgrades that breaks some packages.